### PR TITLE
Uses BdAPI.Patcher instead of an Observer to reveal messages hidden in AboutMe

### DIFF
--- a/Apate.plugin.js
+++ b/Apate.plugin.js
@@ -1,6 +1,6 @@
 /**
  * @name Apate
- * @version 1.2.7
+ * @version 1.2.8
  * @description Hide your secret Discord messages in other messages!
  * @author TheGreenPig, Kehto, Aster
  * @source https://github.com/TheGreenPig/Apate/blob/main/Apate.plugin.js
@@ -42,17 +42,17 @@ module.exports = (() => {
 
 
 			],
-			version: "1.2.7",
+			version: "1.2.8",
 			description: "Apate lets you hide messages in other messages! - Usage: coverText *hiddenText*",
 			github_raw: "https://raw.githubusercontent.com/TheGreenPig/Apate/main/Apate.plugin.js",
 			github: "https://github.com/TheGreenPig/Apate"
 		},
 		changelog: [
 			{
-				title: "Fixed:",
-				type: "fixed",
+				title: "Features Added:",
+				type: "added",
 				items: [
-					"Css hotfix",
+					"Hide messages in the About Me section.",
 				]
 			},
 		],
@@ -858,9 +858,6 @@ module.exports = (() => {
 						if (typeof StegCloak === "undefined") {
 							let stegCloakScript = document.createElement("script");
 							stegCloakScript.src = "https://stegcloak.surge.sh/bundle.js";
-							stegCloakScript.addEventListener("load", (evt) => {
-								stegCloakLoaded();
-							});
 							document.head.append(stegCloakScript);
 						}
 


### PR DESCRIPTION
Also caches the hidden messages to avoid having a one second freeze each time a user profile appears because of the `stegCloak.reveal` function.