### PR TITLE
Allows the user to have the key on the left of the text box (default: false)

### DIFF
--- a/Apate.plugin.js
+++ b/Apate.plugin.js
@@ -54,6 +54,7 @@ module.exports = (() => {
 				items: [
 					"Shift Click for no encryption.",
 					"Added Key position option.",
+					"Added Alt+Control+Enter shortcut to choose the password.",
 				]
 			},
 			{
@@ -451,6 +452,7 @@ module.exports = (() => {
 					hiddenAboutMeText: "",
 					keyPosition: 0,
 					shiftNoEncryption: true,
+					altChoosePassword: true,
 					devMode: false
 				};
 				settings = null;
@@ -901,6 +903,10 @@ module.exports = (() => {
 							new Switch('Shift for no encryption', 'If turned on, shift-clicking the Key or sending a message with Ctrl+Shift+Enter will send the message without encryption. You will have to switch channels for the changes to take effect.', this.settings.shiftNoEncryption, (i) => {
 								this.settings.shiftNoEncryption = i;
 								console.log(`Set "shiftNoEncryption" to ${this.settings.shiftNoEncryption}`);
+							}),
+							new Switch('Alt for choose Password', 'If turned on, you can choose the password you want to use with Ctrl+Alt+Enter. You will have to switch channels for the changes to take effect.', this.settings.altChoosePassword, (i) => {
+								this.settings.altChoosePassword = i;
+								console.log(`Set "altChoosePassword" to ${this.settings.altChoosePassword}`);
 							}),
 						),
 					);
@@ -1427,6 +1433,44 @@ module.exports = (() => {
 					});
 				}
 
+				displayPasswordChooseConfirm() {
+					if (this.settings.showChoosePasswordConfirm) {
+						let checkbox = document.createElement("input");
+						checkbox.setAttribute("type", "checkbox");
+						checkbox.setAttribute("id", "apateDontShowAgain");
+						checkbox.setAttribute("title", "Don't show again.");
+
+						let info = document.createElement("div");
+						info.textContent = "The password you choose will only be used on this message."
+						info.className = "markdown-11q6EU paragraph-3Ejjt0";
+
+						let infoCheckBox = document.createElement("div");
+						infoCheckBox.textContent = "Don't show this message again:"
+						infoCheckBox.className = "markdown-11q6EU paragraph-3Ejjt0";
+						infoCheckBox.appendChild(checkbox)
+
+						let htmlText = document.createElement("div")
+						htmlText.appendChild(info);
+						htmlText.appendChild(document.createElement("br"))
+						htmlText.appendChild(infoCheckBox)
+
+						BdApi.showConfirmationModal("Send message with different encryption?", BdApi.React.createElement(HTMLWrapper, null, htmlText), {
+							confirmText: "Choose password",
+							cancelText: "Cancel",
+							onConfirm: () => {
+								if (document.getElementById("apateDontShowAgain").checked === true) {
+									this.settings.showChoosePasswordConfirm = false;
+									this.saveSettings(this.settings);
+								}
+								this.displayPasswordChoose();
+							},
+
+						});
+					} else {
+						this.displayPasswordChoose();
+					}
+				}
+
 				addKeyButton() {
 
 					let form = document.querySelector(DiscordSelectors.TitleWrap.form.value);
@@ -1461,41 +1505,7 @@ module.exports = (() => {
 
 						button.addEventListener('contextmenu', (ev) => {
 							ev.preventDefault();
-							if (this.settings.showChoosePasswordConfirm) {
-								let checkbox = document.createElement("input");
-								checkbox.setAttribute("type", "checkbox");
-								checkbox.setAttribute("id", "apateDontShowAgain");
-								checkbox.setAttribute("title", "Don't show again.");
-
-								let info = document.createElement("div");
-								info.textContent = "The password you choose will only be used on this message."
-								info.className = "markdown-11q6EU paragraph-3Ejjt0";
-
-								let infoCheckBox = document.createElement("div");
-								infoCheckBox.textContent = "Don't show this message again:"
-								infoCheckBox.className = "markdown-11q6EU paragraph-3Ejjt0";
-								infoCheckBox.appendChild(checkbox)
-
-								let htmlText = document.createElement("div")
-								htmlText.appendChild(info);
-								htmlText.appendChild(document.createElement("br"))
-								htmlText.appendChild(infoCheckBox)
-
-								BdApi.showConfirmationModal("Send message with different encryption?", BdApi.React.createElement(HTMLWrapper, null, htmlText), {
-									confirmText: "Choose password",
-									cancelText: "Cancel",
-									onConfirm: () => {
-										if (document.getElementById("apateDontShowAgain").checked === true) {
-											this.settings.showChoosePasswordConfirm = false;
-											this.saveSettings(this.settings);
-										}
-										this.displayPasswordChoose();
-									},
-
-								});
-							} else {
-								this.displayPasswordChoose();
-							}
+							this.displayPasswordChooseConfirm();
 							return false;
 						}, false);
 					}
@@ -1507,6 +1517,9 @@ module.exports = (() => {
 							if (this.settings.shiftNoEncryption && evt.key === "Enter" && evt.ctrlKey && evt.shiftKey) {
 								evt.preventDefault();
 								this.hideMessage("");
+							} else if(this.settings.altChoosePassword && evt.key === "Enter" && evt.ctrlKey && evt.altKey) {
+								evt.preventDefault();
+								this.displayPasswordChooseConfirm();
 							}
 							else if (evt.key === "Enter" && evt.ctrlKey) {
 								evt.preventDefault();

--- a/Apate.plugin.js
+++ b/Apate.plugin.js
@@ -1,6 +1,6 @@
 /**
  * @name Apate
- * @version 1.2.10
+ * @version 1.2.11
  * @description Hide your secret Discord messages in other messages!
  * @author TheGreenPig, Kehto, Aster
  * @source https://github.com/TheGreenPig/Apate/blob/main/Apate.plugin.js
@@ -42,7 +42,7 @@ module.exports = (() => {
 
 
 			],
-			version: "1.2.10",
+			version: "1.2.11",
 			description: "Apate lets you hide messages in other messages! - Usage: `cover message \*hidden message\*`",
 			github_raw: "https://raw.githubusercontent.com/TheGreenPig/Apate/main/Apate.plugin.js",
 			github: "https://github.com/TheGreenPig/Apate"

--- a/Apate.plugin.js
+++ b/Apate.plugin.js
@@ -906,7 +906,7 @@ module.exports = (() => {
 							}),
 							new Switch('Alt for choose Password', 'If turned on, you can choose the password you want to use with Ctrl+Alt+Enter. You will have to switch channels for the changes to take effect.', this.settings.altChoosePassword, (i) => {
 								this.settings.altChoosePassword = i;
-								console.log(`Set "altChoosePassword" to ${this.settings.altChoosePassword}`);
+								Logger.log(`Set "altChoosePassword" to ${this.settings.altChoosePassword}`);
 							}),
 						),
 					);

--- a/Apate.plugin.js
+++ b/Apate.plugin.js
@@ -161,6 +161,13 @@ module.exports = (() => {
 				`}`,
 			].join("\n");
 
+			let apateLeftKeyCSS = [
+				`.apateKeyButtonContainer {`,
+				`	margin-left: -0.6rem;`,
+				`	margin-right: 0.1rem;`,
+				`}`,
+			].join("\n");
+
 			let apateNoLoadingCSS = [
 				`.apateHiddenMessage.loading {`,
 				`	display: none;`,
@@ -418,6 +425,7 @@ module.exports = (() => {
 					hiddenAboutMe: false,
 					hiddenAboutMeText: "",
 					showKeyButton: true,
+					leftKeyButton: false,
 					devMode: false
 				};
 				settings = null;
@@ -544,8 +552,8 @@ module.exports = (() => {
 				}
 
 				refreshCSS() {
-					let compact, animate, noLoading, simpleBackground, aboutMe;
-					animate = noLoading = simpleBackground = aboutMe = "";
+					let compact, animate, noLoading, simpleBackground, leftKey, aboutMe;
+					animate = noLoading = simpleBackground = leftKey = aboutMe = "";
 
 					let compactClass = BdApi.findModuleByProps("compact", "cozy")?.compact;
 					compact = `.${compactClass} .apateHiddenMessage {
@@ -560,6 +568,9 @@ module.exports = (() => {
 					if (this.settings.simpleBackground) {
 						simpleBackground = apateSimpleCSS;
 					}
+					if (this.settings.leftKeyButton) {
+						leftKey = apateLeftKeyCSS;
+					}
 					if (!this.settings.hiddenAboutMe) {
 						aboutMe = `.apateAboutMeSettings { display: none;}`;
 					}
@@ -567,7 +578,7 @@ module.exports = (() => {
 						aboutMe = `.apateEncrpytionSettings { display: none;}`;
 					}
 					BdApi.clearCSS("apateCSS")
-					BdApi.injectCSS("apateCSS", apateCSS + compact + animate + simpleBackground + apatePasswordCSS + noLoading + aboutMe);
+					BdApi.injectCSS("apateCSS", apateCSS + compact + animate + simpleBackground + apatePasswordCSS + noLoading + leftKey + aboutMe);
 				}
 
 				/**
@@ -857,6 +868,10 @@ module.exports = (() => {
 									BdApi.alert("Can't send messages anymore!", "Since you disabled the key and do not want to use the shortcut either, you will have no way to send messages.");
 								}
 								console.log(`Set "showKeyButton" to ${this.settings.showKeyButton}`);
+							}),
+							new Switch('Left Key button', 'Moves the Key Button on the left of the text box instead of the right. You will have to switch channels for the changes to take effect.', this.settings.leftKeyButton, (i) => {
+								this.settings.leftKeyButton = i;
+								this.refreshCSS();
 							}),
 						),
 					);
@@ -1393,8 +1408,12 @@ module.exports = (() => {
 						return;
 					}
 					if (this.settings.showKeyButton) {
+						if (this.settings.leftKeyButton) {
+							form.querySelector(DiscordSelectors.Textarea.inner).insertBefore(button, form.querySelector(DiscordSelectors.Textarea.textArea));
+						} else {
+							form.querySelector(DiscordSelectors.Textarea.buttons).append(button);
+						}
 
-						form.querySelector(DiscordSelectors.Textarea.buttons).append(button);
 						button.outerHTML = buttonHTML;
 						button = form.querySelector(".keyButton");
 


### PR DESCRIPTION
I personally like having the key on the left instead of at the far right :>
So I figured it could be nice if others could have that option too.

It works especially well when I use another plugin to remove the attach button:
![Discord_i9ZPOZFTA7](https://user-images.githubusercontent.com/16782977/132957884-3b633c1f-b68d-47b5-b4de-9df30c066d64.jpg)

